### PR TITLE
update API models

### DIFF
--- a/album.go
+++ b/album.go
@@ -15,48 +15,28 @@ type albumInfoDataWrapper struct {
 
 // AlbumInfo contains all album information provided by imgur
 type AlbumInfo struct {
-	// The ID for the album
-	ID string `json:"id"`
-	// The title of the album in the gallery
-	Title string `json:"title"`
-	// The description of the album in the gallery
-	Description string `json:"description"`
-	// Time inserted into the gallery, epoch time
-	DateTime int `json:"datetime"`
-	// The ID of the album cover image
-	Cover string `json:"cover"`
-	// The width, in pixels, of the album cover image
-	CoverWidth int `json:"cover_width"`
-	// The height, in pixels, of the album cover image
-	CoverHeight int `json:"cover_height"`
-	// The account username or null if it's anonymous.
-	AccountURL string `json:"account_url"`
-	// The account ID or null if it's anonymous.
-	AccountID int `json:"account_id"`
-	// The privacy level of the album, you can only view public if not logged in as album owner
-	Privacy string `json:"privacy"`
-	// The view layout of the album.
-	Layout string `json:"layout"`
-	// The number of album views
-	Views int `json:"views"`
-	// The URL link to the album
-	Link string `json:"link"`
-	// Indicates if the current user favorited the image. Defaults to false if not signed in.
-	Favorite bool `json:"favorite"`
-	// Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
-	Nsfw bool `json:"nsfw"`
-	// If the image has been categorized by our backend then this will contain the section the image belongs in. (funny, cats, adviceanimals, wtf, etc)
-	Section string `json:"section"`
-	// Order number of the album on the user's album page (defaults to 0 if their albums haven't been reordered)
-	Order int `json:"order"`
-	// OPTIONAL, the deletehash, if you're logged in as the album owner
-	Deletehash string `json:"deletehash,omitempty"`
-	// The total number of images in the album
-	ImagesCount int `json:"images_count"`
-	// An array of all the images in the album (only available when requesting the direct album)
-	Images []ImageInfo `json:"images"`
-	// Current rate limit
-	Limit *RateLimit
+	ID          string      `json:"id"`                   // The ID for the album
+	Title       string      `json:"title"`                // The title of the album in the gallery
+	Description string      `json:"description"`          // The description of the album in the gallery
+	DateTime    int         `json:"datetime"`             // Time inserted into the gallery, epoch time
+	Cover       string      `json:"cover"`                // The ID of the album cover image
+	CoverWidth  int         `json:"cover_width"`          // The width, in pixels, of the album cover image
+	CoverHeight int         `json:"cover_height"`         // The height, in pixels, of the album cover image
+	AccountURL  string      `json:"account_url"`          // The account username or null if it's anonymous.
+	AccountID   int         `json:"account_id"`           // The account ID or null if it's anonymous.
+	Privacy     string      `json:"privacy"`              // The privacy level of the album, you can only view public if not logged in as album owner
+	Layout      string      `json:"layout"`               // The view layout of the album.
+	Views       int         `json:"views"`                // The number of album views
+	Link        string      `json:"link"`                 // The URL link to the album
+	Favorite    bool        `json:"favorite"`             // Indicates if the current user favorited the image. Defaults to false if not signed in.
+	Nsfw        bool        `json:"nsfw"`                 // Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
+	Section     string      `json:"section"`              // If the image has been categorized by our backend then this will contain the section the image belongs in. (funny, cats, adviceanimals, wtf, etc)
+	Order       int         `json:"order"`                // Order number of the album on the user's album page (defaults to 0 if their albums haven't been reordered)
+	Deletehash  string      `json:"deletehash,omitempty"` // OPTIONAL, the deletehash, if you're logged in as the album owner
+	ImagesCount int         `json:"images_count"`         // The total number of images in the album
+	Images      []ImageInfo `json:"images"`               // An array of all the images in the album (only available when requesting the direct album)
+	InGallery   bool        `json:"in_gallery"`           // True if the image has been submitted to the gallery, false if otherwise.
+	Limit       *RateLimit  // Current rate limit
 }
 
 // GetAlbumInfo queries imgur for information on a album

--- a/comment.go
+++ b/comment.go
@@ -2,34 +2,19 @@ package imgur
 
 // Comment is an imgur comment
 type Comment struct {
-	// The ID for the comment
-	ID int `json:"id"`
-	//The ID of the image that the comment is for
-	ImageID string `json:"image_id"`
-	// The comment itself.
-	Comment string `json:"comment"`
-	// Username of the author of the comment
-	Author string `json:"author"`
-	// The account ID for the author
-	AuthorID int `json:"author_id"`
-	// If this comment was done to an album
-	OnAlbum bool `json:"on_album"`
-	//	Number of upvotes for the comment
-	Ups int `json:"ups"`
-	// The ID of the album cover image, this is what should be displayed for album comments
-	AlbumCover string `json:"album_cover"`
-	// The number of downvotes for the comment
-	Downs int `json:"downs"`
-	// the number of upvotes - downvotes
-	Points float32 `json:"points"`
-	// Timestamp of creation, epoch time
-	Datetime int `json:"datetime"`
-	// If this is a reply, this will be the value of the comment_id for the caption this a reply for.
-	ParentID int `json:"parent_id"`
-	// Marked true if this caption has been deleted
-	Deleted bool `json:"deleted"`
-	// The current user's vote on the comment. null if not signed in or if the user hasn't voted on it.
-	Vote string `json:"vote"`
-	// All of the replies for this comment. If there are no replies to the comment then this is an empty set.
-	Children []Comment `json:"children"`
+	ID         int       `json:"id"`          // The ID for the comment
+	ImageID    string    `json:"image_id"`    //The ID of the image that the comment is for
+	Comment    string    `json:"comment"`     // The comment itself.
+	Author     string    `json:"author"`      // Username of the author of the comment
+	AuthorID   int       `json:"author_id"`   // The account ID for the author
+	OnAlbum    bool      `json:"on_album"`    // If this comment was done to an album
+	AlbumCover string    `json:"album_cover"` // The ID of the album cover image, this is what should be displayed for album comments
+	Ups        int       `json:"ups"`         //	Number of upvotes for the comment
+	Downs      int       `json:"downs"`       // The number of downvotes for the comment
+	Points     float32   `json:"points"`      // the number of upvotes - downvotes
+	Datetime   int       `json:"datetime"`    // Timestamp of creation, epoch time
+	ParentID   int       `json:"parent_id"`   // If this is a reply, this will be the value of the comment_id for the caption this a reply for.
+	Deleted    bool      `json:"deleted"`     // Marked true if this caption has been deleted
+	Vote       string    `json:"vote"`        // The current user's vote on the comment. null if not signed in or if the user hasn't voted on it.
+	Children   []Comment `json:"children"`    // All of the replies for this comment. If there are no replies to the comment then this is an empty set.
 }

--- a/galleryAlbum.go
+++ b/galleryAlbum.go
@@ -15,62 +15,34 @@ type galleryAlbumInfoDataWrapper struct {
 
 // GalleryAlbumInfo contains all information provided by imgur of a gallery album
 type GalleryAlbumInfo struct {
-	// The ID for the album
-	ID string `json:"id"`
-	// The title of the album in the gallery
-	Title string `json:"title"`
-	// The description of the album in the gallery
-	Description string `json:"description"`
-	// Time inserted into the gallery, epoch time
-	DateTime int `json:"datetime"`
-	// The ID of the album cover image
-	Cover string `json:"cover"`
-	// The width, in pixels, of the album cover image
-	CoverWidth int `json:"cover_width"`
-	// The height, in pixels, of the album cover image
-	CoverHeight int `json:"cover_height"`
-	// The account username or null if it's anonymous.
-	AccountURL string `json:"account_url"`
-	// The account ID or null if it's anonymous.
-	AccountID int `json:"account_id"`
-	// The privacy level of the album, you can only view public if not logged in as album owner
-	Privacy string `json:"privacy"`
-	// The view layout of the album.
-	Layout string `json:"layout"`
-	// The number of album views
-	Views int `json:"views"`
-	// The URL link to the album
-	Link string `json:"link"`
-	// Upvotes for the image
-	Ups int `json:"ups"`
-	// Number of downvotes for the image
-	Downs int `json:"downs"`
-	// Upvotes minus downvotes
-	Points int `json:"points"`
-	// Imgur popularity score
-	Score int `json:"score"`
-	// if it's an album or not
-	IsAlbum bool `json:"is_album"`
-	// The current user's vote on the album. null if not signed in or if the user hasn't voted on it.
-	Vote string `json:"vote"`
-	// Indicates if the current user favorited the image. Defaults to false if not signed in.
-	Favorite bool `json:"favorite"`
-	// Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
-	Nsfw bool `json:"nsfw"`
-	// Number of comments on the gallery album.
-	CommentCount int `json:"comment_count"`
-	// Up to 10 top level comments, sorted by "best".
-	CommentPreview []Comment `json:"comment_preview"`
-	// Topic of the gallery album.
-	Topic string `json:"topic"`
-	// Topic ID of the gallery album.
-	TopicID int `json:"topic_id"`
-	// The total number of images in the album
-	ImagesCount int `json:"images_count"`
-	// An array of all the images in the album (only available when requesting the direct album)
-	Images []ImageInfo `json:"images,omitempty"`
-	// Current rate limit
-	Limit *RateLimit
+	ID           string      `json:"id"`               // The ID for the album
+	Title        string      `json:"title"`            // The title of the album in the gallery
+	Description  string      `json:"description"`      // The description of the album in the gallery
+	DateTime     int         `json:"datetime"`         // Time inserted into the gallery, epoch time
+	Cover        string      `json:"cover"`            // The ID of the album cover image
+	CoverWidth   int         `json:"cover_width"`      // The width, in pixels, of the album cover image
+	CoverHeight  int         `json:"cover_height"`     // The height, in pixels, of the album cover image
+	AccountURL   string      `json:"account_url"`      // The account username or null if it's anonymous.
+	AccountID    int         `json:"account_id"`       // The account ID or null if it's anonymous.
+	Privacy      string      `json:"privacy"`          // The privacy level of the album, you can only view public if not logged in as album owner
+	Layout       string      `json:"layout"`           // The view layout of the album.
+	Views        int         `json:"views"`            // The number of album views
+	Link         string      `json:"link"`             // The URL link to the album
+	Ups          int         `json:"ups"`              // Upvotes for the image
+	Downs        int         `json:"downs"`            // Number of downvotes for the image
+	Points       int         `json:"points"`           // Upvotes minus downvotes
+	Score        int         `json:"score"`            // Imgur popularity score
+	IsAlbum      bool        `json:"is_album"`         // if it's an album or not
+	Vote         string      `json:"vote"`             // The current user's vote on the album. null if not signed in or if the user hasn't voted on it.
+	Favorite     bool        `json:"favorite"`         // Indicates if the current user favorited the image. Defaults to false if not signed in.
+	Nsfw         bool        `json:"nsfw"`             // Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
+	CommentCount int         `json:"comment_count"`    // Number of comments on the gallery album.
+	Topic        string      `json:"topic"`            // Topic of the gallery album.
+	TopicID      int         `json:"topic_id"`         // Topic ID of the gallery album.
+	ImagesCount  int         `json:"images_count"`     // The total number of images in the album
+	Images       []ImageInfo `json:"images,omitempty"` // An array of all the images in the album (only available when requesting the direct album)
+	InMostViral  bool        `json:"in_most_viral"`    // Indicates if the album is in the most viral gallery or not.
+	Limit        *RateLimit  // Current rate limit
 }
 
 // GetGalleryAlbumInfo queries imgur for information on a gallery album

--- a/galleryImage.go
+++ b/galleryImage.go
@@ -15,72 +15,39 @@ type galleryImageInfoDataWrapper struct {
 
 // GalleryImageInfo contains all gallery image information provided by imgur
 type GalleryImageInfo struct {
-	// The ID for the image
-	ID string `json:"id"`
-	// The title of the image.
-	Title string `json:"title"`
-	// Description of the image.
-	Description string `json:"description"`
-	// Time uploaded, epoch time
-	Datetime int `json:"datetime"`
-	// Image MIME type.
-	MimeType string `json:"type"`
-	// is the image animated
-	Animated bool `json:"animated"`
-	// The width of the image in pixels
-	Width int `json:"width"`
-	// The height of the image in pixels
-	Height int `json:"height"`
-	// The size of the image in bytes
-	Size int `json:"size"`
-	// The number of image views
-	Views int `json:"views"`
-	// Bandwidth consumed by the image in bytes
-	Bandwidth int `json:"bandwidth"`
-	// OPTIONAL, the deletehash, if you're logged in as the image owner
-	Deletehash string `json:"deletehash,omitempty"`
-	// The direct link to the the image. (Note: if fetching an animated GIF that was over 20MB in original size, a .gif thumbnail will be returned)
-	Link string `json:"link"`
-	// OPTIONAL, The .gifv link. Only available if the image is animated and type is 'image/gif'.
-	Gifv string `json:"gifv,omitempty"`
-	// OPTIONAL, The direct link to the .mp4. Only available if the image is animated and type is 'image/gif'.
-	Mp4 string `json:"mp4,omitempty"`
-	// OPTIONAL, The direct link to the .webm. Only available if the image is animated and type is 'image/gif'.
-	Webm string `json:"webm,omitempty"`
-	// OPTIONAL, Whether the image has a looping animation. Only available if the image is animated and type is 'image/gif'.
-	Looping bool `json:"looping,omitempty"`
-	// The current user's vote on the album. null if not signed in or if the user hasn't voted on it.
-	Vote string `json:"vote"`
-	// Indicates if the current user favorited the image. Defaults to false if not signed in.
-	Favorite bool `json:"favorite"`
-	// Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
-	Nsfw bool `json:"nsfw"`
-	// Number of comments on the gallery album.
-	CommentCount int `json:"comment_count"`
-	// Up to 10 top level comments, sorted by "best".
-	CommentPreview []Comment `json:"comment_preview"`
-	// Topic of the gallery album.
-	Topic string `json:"topic"`
-	// Topic ID of the gallery album.
-	TopicID int `json:"topic_id"`
-	// If the image has been categorized by our backend then this will contain the section the image belongs in. (funny, cats, adviceanimals, wtf, etc)
-	Section string `json:"section"`
-	// The username of the account that uploaded it, or null.
-	AccountURL string `json:"account_url"`
-	// The account ID of the account that uploaded it, or null.
-	AccountID int `json:"account_id"`
-	// Upvotes for the image
-	Ups int `json:"ups"`
-	// Number of downvotes for the image
-	Downs int `json:"downs"`
-	// Upvotes minus downvotes
-	Points int `json:"points"`
-	// Imgur popularity score
-	Score int `json:"score"`
-	// if it's an album or not
-	IsAlbum bool `json:"is_album"`
-	// Current rate limit
-	Limit *RateLimit
+	ID           string     `json:"id"`                   // The ID for the image
+	Title        string     `json:"title"`                // The title of the image.
+	Description  string     `json:"description"`          // Description of the image.
+	Datetime     int        `json:"datetime"`             // Time uploaded, epoch time
+	MimeType     string     `json:"type"`                 // Image MIME type.
+	Animated     bool       `json:"animated"`             // is the image animated
+	Width        int        `json:"width"`                // The width of the image in pixels
+	Height       int        `json:"height"`               // The height of the image in pixels
+	Size         int        `json:"size"`                 // The size of the image in bytes
+	Views        int        `json:"views"`                // The number of image views
+	Bandwidth    int        `json:"bandwidth"`            // Bandwidth consumed by the image in bytes
+	Deletehash   string     `json:"deletehash,omitempty"` // OPTIONAL, the deletehash, if you're logged in as the image owner
+	Link         string     `json:"link"`                 // The direct link to the the image. (Note: if fetching an animated GIF that was over 20MB in original size, a .gif thumbnail will be returned)
+	Gifv         string     `json:"gifv,omitempty"`       // OPTIONAL, The .gifv link. Only available if the image is animated and type is 'image/gif'.
+	Mp4          string     `json:"mp4,omitempty"`        // OPTIONAL, The direct link to the .mp4. Only available if the image is animated and type is 'image/gif'.
+	Mp4Size      int        `json:"mp4_size,omitempty"`   // OPTIONAL, The Content-Length of the .mp4. Only available if the image is animated and type is 'image/gif'. Note that a zero value (0) is possible if the video has not yet been generated
+	Looping      bool       `json:"looping,omitempty"`    // OPTIONAL, Whether the image has a looping animation. Only available if the image is animated and type is 'image/gif'.
+	Vote         string     `json:"vote"`                 // The current user's vote on the album. null if not signed in or if the user hasn't voted on it.
+	Favorite     bool       `json:"favorite"`             // Indicates if the current user favorited the image. Defaults to false if not signed in.
+	Nsfw         bool       `json:"nsfw"`                 // Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
+	CommentCount int        `json:"comment_count"`        // Number of comments on the gallery album.
+	Topic        string     `json:"topic"`                // Topic of the gallery album.
+	TopicID      int        `json:"topic_id"`             // Topic ID of the gallery album.
+	Section      string     `json:"section"`              // If the image has been categorized by our backend then this will contain the section the image belongs in. (funny, cats, adviceanimals, wtf, etc)
+	AccountURL   string     `json:"account_url"`          // The username of the account that uploaded it, or null.
+	AccountID    int        `json:"account_id"`           // The account ID of the account that uploaded it, or null.
+	Ups          int        `json:"ups"`                  // Upvotes for the image
+	Downs        int        `json:"downs"`                // Number of downvotes for the image
+	Points       int        `json:"points"`               // Upvotes minus downvotes
+	Score        int        `json:"score"`                // Imgur popularity score
+	IsAlbum      bool       `json:"is_album"`             // if it's an album or not
+	InMostViral  bool       `json:"in_most_viral"`        // Indicates if the album is in the most viral gallery or not.
+	Limit        *RateLimit // Current rate limit
 }
 
 // GetGalleryImageInfo queries imgur for information on a image

--- a/image.go
+++ b/image.go
@@ -15,52 +15,30 @@ type imageInfoDataWrapper struct {
 
 // ImageInfo contains all image information provided by imgur
 type ImageInfo struct {
-	// The ID for the image
-	ID string `json:"id"`
-	// The title of the image.
-	Title string `json:"title"`
-	// Description of the image.
-	Description string `json:"description"`
-	// Time uploaded, epoch time
-	Datetime int `json:"datetime"`
-	// Image MIME type.
-	MimeType string `json:"type"`
-	// is the image animated
-	Animated bool `json:"animated"`
-	// The width of the image in pixels
-	Width int `json:"width"`
-	// The height of the image in pixels
-	Height int `json:"height"`
-	// The size of the image in bytes
-	Size int `json:"size"`
-	// The number of image views
-	Views int `json:"views"`
-	// Bandwidth consumed by the image in bytes
-	Bandwidth int `json:"bandwidth"`
-	// OPTIONAL, the deletehash, if you're logged in as the image owner
-	Deletehash string `json:"deletehash,omitempty"`
-	// OPTIONAL, the original filename, if you're logged in as the image owner
-	Name string `json:"name,omitempty"`
-	// If the image has been categorized by our backend then this will contain the section the image belongs in. (funny, cats, adviceanimals, wtf, etc)
-	Section string `json:"section"`
-	// The direct link to the the image. (Note: if fetching an animated GIF that was over 20MB in original size, a .gif thumbnail will be returned)
-	Link string `json:"link"`
-	// OPTIONAL, The .gifv link. Only available if the image is animated and type is 'image/gif'.
-	Gifv string `json:"gifv,omitempty"`
-	// OPTIONAL, The direct link to the .mp4. Only available if the image is animated and type is 'image/gif'.
-	Mp4 string `json:"mp4,omitempty"`
-	// OPTIONAL, The direct link to the .webm. Only available if the image is animated and type is 'image/gif'.
-	Webm string `json:"webm,omitempty"`
-	// OPTIONAL, Whether the image has a looping animation. Only available if the image is animated and type is 'image/gif'.
-	Looping bool `json:"looping,omitempty"`
-	// Indicates if the current user favorited the image. Defaults to false if not signed in.
-	Favorite bool `json:"favorite"`
-	// Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
-	Nsfw bool `json:"nsfw"`
-	// The current user's vote on the album. null if not signed in, if the user hasn't voted on it, or if not submitted to the gallery.
-	Vote string `json:"vote"`
-	// Current rate limit
-	Limit *RateLimit
+	ID          string     `json:"id"`                   // The ID for the image
+	Title       string     `json:"title"`                // The title of the image.
+	Description string     `json:"description"`          // Description of the image.
+	Datetime    int        `json:"datetime"`             // Time uploaded, epoch time
+	MimeType    string     `json:"type"`                 // Image MIME type.
+	Animated    bool       `json:"animated"`             // is the image animated
+	Width       int        `json:"width"`                // The width of the image in pixels
+	Height      int        `json:"height"`               // The height of the image in pixels
+	Size        int        `json:"size"`                 // The size of the image in bytes
+	Views       int        `json:"views"`                // The number of image views
+	Bandwidth   int        `json:"bandwidth"`            // Bandwidth consumed by the image in bytes
+	Deletehash  string     `json:"deletehash,omitempty"` // OPTIONAL, the deletehash, if you're logged in as the image owner
+	Name        string     `json:"name,omitempty"`       // OPTIONAL, the original filename, if you're logged in as the image owner
+	Section     string     `json:"section"`              // If the image has been categorized by our backend then this will contain the section the image belongs in. (funny, cats, adviceanimals, wtf, etc)
+	Link        string     `json:"link"`                 // The direct link to the the image. (Note: if fetching an animated GIF that was over 20MB in original size, a .gif thumbnail will be returned)
+	Gifv        string     `json:"gifv,omitempty"`       // OPTIONAL, The .gifv link. Only available if the image is animated and type is 'image/gif'.
+	Mp4         string     `json:"mp4,omitempty"`        // OPTIONAL, The direct link to the .mp4. Only available if the image is animated and type is 'image/gif'.
+	Mp4Size     int        `json:"mp4_size,omitempty"`   // OPTIONAL, The Content-Length of the .mp4. Only available if the image is animated and type is 'image/gif'. Note that a zero value (0) is possible if the video has not yet been generated
+	Looping     bool       `json:"looping,omitempty"`    // OPTIONAL, Whether the image has a looping animation. Only available if the image is animated and type is 'image/gif'.
+	Favorite    bool       `json:"favorite"`             // Indicates if the current user favorited the image. Defaults to false if not signed in.
+	Nsfw        bool       `json:"nsfw"`                 // Indicates if the image has been marked as nsfw or not. Defaults to null if information is not available.
+	Vote        string     `json:"vote"`                 // The current user's vote on the album. null if not signed in, if the user hasn't voted on it, or if not submitted to the gallery.
+	InGallery   bool       `json:"in_gallery"`           // True if the image has been submitted to the gallery, false if otherwise.
+	Limit       *RateLimit // Current rate limit
 }
 
 // GetImageInfo queries imgur for information on a image


### PR DESCRIPTION
ref: https://api.imgur.com/changelog

change highlights:
 - Imgur no longer generates webm. Removed the webm response from the GalleryImage and Image models. - 6/3/16
 - Removed comment_preview from the Gallery Image and Gallery Album models. - 4/11/16
 - Added webm_size and mp4_size to Gallery Image and Image models. - 4/8/16
 - Added in_gallery to image and album models. - 4/6/16


https://api.imgur.com/models/image
https://api.imgur.com/models/album
https://api.imgur.com/models/gallery_album
https://api.imgur.com/models/gallery_image
https://api.imgur.com/models/comment